### PR TITLE
processor map values need - to prevent mapping to wrong processor

### DIFF
--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-gcp/cloud"
 	"sigs.k8s.io/cluster-api-provider-gcp/cloud/providerid"
 	"sigs.k8s.io/cluster-api-provider-gcp/cloud/services/shared"
+	"sigs.k8s.io/cluster-api-provider-gcp/util/processors"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 	"sigs.k8s.io/cluster-api/util"
@@ -270,31 +271,13 @@ func (m *MachineScope) InstanceImageSpec() *compute.AttachedDisk {
 
 // MinCPUPlatform returns the min cpu platform for the machine pool.
 func (m *MachineScope) MinCPUPlatform() string {
-	// map of machine types to their respective processors (e2 cannot have a min cpu platform set, so it is not included here)
-	var processors = map[string]string{
-		"n1":  "Intel Skylake",
-		"n2":  "Intel Ice Lake",
-		"n2d": "AMD Milan",
-		"c3":  "Intel Sapphire Rapids",
-		"c2":  "Intel Cascade Lake",
-		"t2d": "AMD Milan",
-		"m1":  "Intel Skylake",
-	}
-
 	// If the min cpu platform is set on the GCPMachinePool, use the specified value.
 	if m.GCPMachine.Spec.MinCPUPlatform != nil {
 		return *m.GCPMachine.Spec.MinCPUPlatform
 	}
 
-	// If the min cpu platform is not set on the GCPMachinePool, use the default value for the machine type.
-	for machineType, processor := range processors {
-		if strings.HasPrefix(m.GCPMachine.Spec.InstanceType, machineType) {
-			return processor
-		}
-	}
-
-	// If the machine type is not recognized, return an empty string (This will hand off the processor selection to GCP).
-	return ""
+	// Return the latest processor for the instance type or empty string if unknown instance type
+	return processors.GetLatestProcessor(m.GCPMachine.Spec.InstanceType)
 }
 
 // InstanceAdditionalDiskSpec returns compute instance additional attched-disk spec.

--- a/cloud/scope/machinepool.go
+++ b/cloud/scope/machinepool.go
@@ -35,6 +35,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-gcp/cloud"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-gcp/exp/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-gcp/util/processors"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 	clusterv1exp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
@@ -275,31 +276,13 @@ func (m *MachinePoolScope) InstanceImageSpec() *compute.AttachedDisk {
 
 // MinCPUPlatform returns the min cpu platform for the machine pool.
 func (m *MachinePoolScope) MinCPUPlatform() string {
-	// map of machine types to their respective processors (e2 cannot have a min cpu platform set, so it is not included here)
-	var processors = map[string]string{
-		"n1":  "Intel Skylake",
-		"n2":  "Intel Ice Lake",
-		"n2d": "AMD Milan",
-		"c3":  "Intel Sapphire Rapids",
-		"c2":  "Intel Cascade Lake",
-		"t2d": "AMD Milan",
-		"m1":  "Intel Skylake",
-	}
-
 	// If the min cpu platform is set on the GCPMachinePool, use the specified value.
 	if m.GCPMachinePool.Spec.MinCPUPlatform != nil {
 		return *m.GCPMachinePool.Spec.MinCPUPlatform
 	}
 
-	// If the min cpu platform is not set on the GCPMachinePool, use the default value for the machine type.
-	for machineType, processor := range processors {
-		if strings.HasPrefix(m.GCPMachinePool.Spec.InstanceType, machineType) {
-			return processor
-		}
-	}
-
-	// If the machine type is not recognized, return an empty string (This will hand off the processor selection to GCP).
-	return ""
+	// Return the latest processor for the instance type or empty string if unknown instance type
+	return processors.GetLatestProcessor(m.GCPMachinePool.Spec.InstanceType)
 }
 
 // Zone returns the zone for the machine pool.

--- a/cloud/scope/machinepool_test.go
+++ b/cloud/scope/machinepool_test.go
@@ -1,0 +1,72 @@
+package scope_test
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-gcp/cloud"
+	"sigs.k8s.io/cluster-api-provider-gcp/cloud/scope"
+	"sigs.k8s.io/cluster-api-provider-gcp/exp/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-gcp/util/processors"
+	clusterv1exp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("GCPManagedMachinePool Scope", func() {
+	var TestMachinePoolScope *scope.MachinePoolScope
+	var getter cloud.ClusterGetter
+	var t *testing.T
+
+	BeforeEach(func() {
+		// Register the MachinePool, GCPMachinePool and GCPMachinePoolList in a schema.
+		schema, err := infrav1.SchemeBuilder.Register(&clusterv1exp.MachinePool{}, &v1beta1.GCPMachinePool{}, &v1beta1.GCPMachinePoolList{}).Build()
+		// Make sure no errors were triggered.
+		assert.Nil(t, err)
+
+		// Create a controller fake client.
+		// It's best to use envtest but in this case we are not really using the client
+		// just passing it as parameter to the NewMachinePoolScope to test the mincpu.
+		testClient := fake.NewClientBuilder().WithScheme(schema).Build()
+
+		// Create the machinepool scope
+		params := scope.MachinePoolScopeParams{
+			Client:        testClient,
+			ClusterGetter: getter,
+			MachinePool: &clusterv1exp.MachinePool{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec:       clusterv1exp.MachinePoolSpec{},
+			},
+			GCPMachinePool: &v1beta1.GCPMachinePool{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec:       v1beta1.GCPMachinePoolSpec{},
+			},
+		}
+		TestMachinePoolScope, _ = scope.NewMachinePoolScope(params)
+
+		// Make sure the machinepool scope is created correctly.
+		assert.Nil(t, err)
+		assert.NotNil(t, TestMachinePoolScope)
+
+	})
+
+	Describe("Min CPU Mappings", func() {
+		Context("instance types", func() {
+			It("should match all", func() {
+				for k := range processors.Processors {
+					TestMachinePoolScope.GCPMachinePool.Spec.InstanceType = fmt.Sprintf("%sstandard-8", k)
+					Expect(TestMachinePoolScope.MinCPUPlatform()).To(Equal(processors.Processors[k]))
+				}
+			})
+			It("should not match n2", func() {
+				TestMachinePoolScope.GCPMachinePool.Spec.InstanceType = "n2d-standard-8"
+				Expect(TestMachinePoolScope.MinCPUPlatform()).NotTo(Equal(processors.Processors["n2"]))
+			})
+		})
+	})
+})

--- a/util/processors/defaults.go
+++ b/util/processors/defaults.go
@@ -1,0 +1,26 @@
+// Package processors provides a mapping of instancetype prefix to latest available processor.
+package processors
+
+import "strings"
+
+// Processors is a map of instance type prefixes to the latest processor available in GCP (e2 cannot have a min cpu platform set, so it is not included here).
+var Processors = map[string]string{
+	"n1-":  "Intel Skylake",
+	"n2-":  "Intel Ice Lake",
+	"n2d-": "AMD Milan",
+	"c3-":  "Intel Sapphire Rapids",
+	"c2-":  "Intel Cascade Lake",
+	"t2d-": "AMD Milan",
+	"m1-":  "Intel Skylake",
+}
+
+// GetLatestProcessor returns the latest processor available for a given instance type.
+func GetLatestProcessor(instanceType string) string {
+	for machineType, processor := range Processors {
+		if strings.HasPrefix(instanceType, machineType) {
+			return processor
+		}
+	}
+	// If the machine type is not recognized, return an empty string (This will hand off the processor selection to GCP).
+	return ""
+}

--- a/util/processors/defaults_test.go
+++ b/util/processors/defaults_test.go
@@ -1,0 +1,58 @@
+package processors_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/cluster-api-provider-gcp/util/processors"
+)
+
+var _ = Describe("Processors", func() {
+
+	var n2InstTypes = []string{"n2-slow-8", "n2-test-8"}
+	var n2dInstTypes = []string{"n2d-medium-4", "n2d-fast-23"}
+	var c2InstTypes = []string{"c2-medium-4", "c2-fast-23"}
+	var t2dInstTypes = []string{"t2d-medium-4", "t2d-fast-23"}
+
+	Describe("Mapping Instance Types", func() {
+		Context("n2 instance types", func() {
+			It("should match n2 processor", func() {
+				for _, instType := range n2InstTypes {
+					Expect(processors.GetLatestProcessor(instType)).To(Equal(processors.Processors["n2-"]))
+				}
+			})
+		})
+
+		Context("c2 intstance types", func() {
+			It("should match c2 processor", func() {
+				for _, instType := range c2InstTypes {
+					Expect(processors.GetLatestProcessor(instType)).To(Equal(processors.Processors["c2-"]))
+				}
+			})
+		})
+
+		Context("n2d instance types", func() {
+			It("should match n2d processor", func() {
+				for _, instType := range n2dInstTypes {
+					Expect(processors.GetLatestProcessor(instType)).To(Equal(processors.Processors["n2d-"]))
+				}
+			})
+		})
+
+		Context("n2d instance types", func() {
+			It("should not match n2 processor", func() {
+				for _, instType := range n2dInstTypes {
+					Expect(processors.GetLatestProcessor(instType)).NotTo(Equal(processors.Processors["n2-"]))
+				}
+			})
+		})
+
+		Context("t2d instance types", func() {
+			It("should match t2d processor", func() {
+				for _, instType := range t2dInstTypes {
+					Expect(processors.GetLatestProcessor(instType)).To(Equal(processors.Processors["t2d-"]))
+				}
+			})
+		})
+	})
+})

--- a/util/processors/processors_suite_test.go
+++ b/util/processors/processors_suite_test.go
@@ -1,0 +1,13 @@
+package processors_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestProcessors(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Processors Suite")
+}


### PR DESCRIPTION
 This PR fixes a bug when mapping processors to instance types.   When ranging over maps order is not guaranteed, even if order was enforced you could match instancetype abc to processor ab.   By adding the hyphen we should ensure an exact prefix match.

Also added testing around this function we could add more testing in the future for the machine pools.   