### PR TITLE
Support custom metadata

### DIFF
--- a/cloud/scope/machinepool.go
+++ b/cloud/scope/machinepool.go
@@ -402,6 +402,7 @@ func (m *MachinePoolScope) InstanceGroupTemplateBuilder(bootstrapData string) *c
 	instanceTemplate.Properties.Disks = append(instanceTemplate.Properties.Disks, m.InstanceAdditionalDiskSpec()...)
 	instanceTemplate.Properties.ServiceAccounts = append(instanceTemplate.Properties.ServiceAccounts, m.InstanceServiceAccountsSpec())
 	instanceTemplate.Properties.NetworkInterfaces = append(instanceTemplate.Properties.NetworkInterfaces, m.InstanceNetworkInterfaceSpec())
+	instanceTemplate.Properties.Metadata.Items = append(instanceTemplate.Properties.Metadata.Items, m.InstanceAdditionalMetadataSpec())
 
 	return instanceTemplate
 }


### PR DESCRIPTION
Propagate the additionalMetadata to instance template to support blocking Project-Wide SSH Keys for VM Instances