### PR TITLE
use template from templates/custom_network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -430,7 +430,7 @@ release-metadata: $(RELEASE_DIR)
 
 .PHONY: release-templates
 release-templates: $(RELEASE_DIR)
-	cp templates/cluster-template* $(RELEASE_DIR)/
+	cp templates/custom_network/cluster-template* $(RELEASE_DIR)/
 
 .PHONY: release-staging
 release-staging: ## Builds and push container images to the staging bucket.


### PR DESCRIPTION
`release-templates` is bombing

```
➜ make release-templates
cp templates/cluster-template* out/
cp: templates/cluster-template*: No such file or directory
make: *** [release-templates] Error 1
```