### PR TITLE
Currently `cluster-api-provider-gcp` uses `sigs.k8s.io/controller-run…

### DIFF
--- a/exp/api/v1beta1/webhook_suite_test.go
+++ b/exp/api/v1beta1/webhook_suite_test.go
@@ -36,7 +36,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
@@ -98,9 +97,6 @@ var _ = BeforeSuite(func() {
 			CertDir: webhookInstallOptions.LocalServingCertDir,
 		}),
 		LeaderElection: false,
-		Metrics: server.Options{
-			BindAddress: "0",
-		},
 	})
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Currently `cluster-api-provider-gcp` uses `sigs.k8s.io/controller-runtime v0.16.5` whereas `cluster-api-provider-aws` uses `sigs.k8s.io/controller-runtime v0.11.2`

In `machine-lifecycle-controller`, when we use both `cluster-api-provider-gcp` and `cluster-api-provider-aws`, the mismatch in `sigs.k8s.io/controller-runtime` module version is resulting in some missing packages when resolving the GO module file. 

A simpler fix was to remove the dependency of the `sigs.k8s.io/controller-runtime/pkg/metrics/server` package in `cluster-api-provider-gcp` as it was the least intensive approach from a code-refactoring perspective.